### PR TITLE
RUBY_DESCRIPTION, minor formatting, width

### DIFF
--- a/check.rb
+++ b/check.rb
@@ -35,12 +35,16 @@ uri = URI("https://#{host}")
 ssl_version = ARGV.shift
 verify_mode = ARGV.any? ? OpenSSL::SSL.const_get(ARGV.shift) : OpenSSL::SSL::VERIFY_PEER
 
-ruby_version = RUBY_VERSION.dup
-ruby_version << "p#{RUBY_PATCHLEVEL}" if defined?(RUBY_PATCHLEVEL)
-ruby_version << " (#{RUBY_RELEASE_DATE} revision #{RUBY_REVISION})"
-ruby_version << " [#{RUBY_PLATFORM}]"
+if defined?(RUBY_DESCRIPTION)
+  ruby_version = RUBY_DESCRIPTION
+else
+  ruby_version = RUBY_VERSION.dup
+  ruby_version << "p#{RUBY_PATCHLEVEL}" if defined?(RUBY_PATCHLEVEL)
+  ruby_version << " (#{RUBY_RELEASE_DATE} revision #{RUBY_REVISION})"
+  ruby_version << " [#{RUBY_PLATFORM}]"
+end
 
-puts "Here's your Ruby and OpenSSL environment:"
+puts "", "Here's your Ruby and OpenSSL environment:"
 puts
 puts "Ruby:           %s" % ruby_version
 puts "RubyGems:       %s" % Gem::VERSION if defined?(Gem::VERSION)
@@ -110,14 +114,14 @@ rescue => error
   case error.message
   # Check for certificate errors
   when /certificate verify failed/
-    abort "Your Ruby can't connect to #{host} because you are missing the certificate " \
+    abort "Your Ruby can't connect to #{host} because you are missing the certificate\n" \
       "files OpenSSL needs to verify you are connecting to the genuine #{host} servers."
   # Check for TLS version errors
   when /read server hello A/, /tlsv1 alert protocol version/
     if ssl_version == "TLSv1_3"
       abort "Your Ruby can't connect to #{host} because #{ssl_version} isn't supported yet."
     else
-      abort "Your Ruby can't connect to #{host} because your version of OpenSSL is too old. " \
+      abort "Your Ruby can't connect to #{host} because your version of OpenSSL is too old.\n" \
         "You'll need to upgrade your OpenSSL install and/or recompile Ruby to use a newer OpenSSL."
     end
   else
@@ -138,13 +142,23 @@ end
 guide_url = "http://ruby.to/ssl-check-failed"
 if bundler_status =~ /success/ && rubygems_status =~ /success/
   # Whoa, it seems like it's working!
-  puts "Hooray! This Ruby can connect to #{host}. You are all set to use Bundler and RubyGems. 👌"
+  puts "Hooray! This Ruby can connect to #{host}.",
+       "You are all set to use Bundler and RubyGems. 👌", ""
 elsif rubygems_status !~ /success/
-  puts "It looks like Ruby and Bundler can connect to #{host}, but RubyGems itself cannot. You can likely solve this by manually downloading and installing a RubyGems update. Visit #{guide_url} for instructions on how to manually upgrade RubyGems. 💎"
+  puts "It looks like Ruby and Bundler can connect to #{host}, but RubyGems itself",
+       "cannot. You can likely solve this by manually downloading and installing a",
+       "RubyGems update. Visit #{guide_url} for instructions on how to manually upgrade RubyGems. 💎"
 elsif bundler_status !~ /success/
-  puts "Although your Ruby installation and RubyGems can both connect to #{host}, Bundler is having trouble. The most likely way to fix this is to upgrade Bundler by running `gem install bundler`. Run this script again after doing that to make sure everything is all set. If you're still having trouble, check out the troubleshooting guide at #{guide_url} 📦"
+  puts "Although your Ruby installation and RubyGems can both connect to #{host},",
+       "Bundler is having trouble. The most likely way to fix this is to upgrade",
+       "Bundler by running `gem install bundler`. Run this script again after doing",
+       "that to make sure everything is all set. If you're still having trouble,",
+       "check out the troubleshooting guide at #{guide_url} 📦"
 else
-  puts "For some reason, your Ruby installation can connect to #{host}, but neither RubyGems nor Bundler can. The most likely fix is to manually upgrade RubyGems by following the instructions at #{guide_url}. After you've done that, run `gem install bundler` to upgrade Bundler, and then run this script again to make sure everything worked. ❣️"
+  puts "For some reason, your Ruby installation can connect to #{host}, but neither",
+  "RubyGems nor Bundler can. The most likely fix is to manually upgrade RubyGems by",
+  "following the instructions at #{guide_url}. After you've done that, run `gem install",
+  "bundler` to upgrade Bundler, and then run this script again to make sure everything worked. ❣️"
 end
 
 def tls12_supported?
@@ -162,7 +176,7 @@ end
 unless tls12_supported?
   puts
   puts "WARNING: Although your Ruby can connect to #{host} today, your OpenSSL is very old! 👴"
-  puts "WARNING: You will need to upgrade OpenSSL before January 2018 in order to keep using #{host}."
+  puts "WARNING: You will need to upgrade OpenSSL to use #{host}."
   abort
 end
 


### PR DESCRIPTION
Using Ruby 2.7 and later, `RUBY_REVISION` is the full Git commit SHA.  Use `RUBY_DESCRIPTION` if defined.

Made additional changes to format long output lines into shorter separate lines.  Passing example output:

```
PS C:\Greg\GitHub> ruby ruby-ssl-check/check.rb

Here's your Ruby and OpenSSL environment:

Ruby:           ruby 2.8.0dev (2020-05-31T10:48:14Z master 5a79d8e050) [x64-mingw32]
RubyGems:       3.2.0.pre1
Bundler:        2.2.0.dev
Compiled with:  OpenSSL 1.1.1g  21 Apr 2020
Loaded version: OpenSSL 1.1.1g  21 Apr 2020
SSL_CERT_FILE:  C:/Greg/ruby-mingw/ssl/cert.pem
SSL_CERT_DIR:   C:/Greg/ruby-mingw/ssl/certs

With that out of the way, let's see if you can connect to rubygems.org...

Bundler connection to rubygems.org:       success ✅
RubyGems connection to rubygems.org:      success ✅
Ruby net/http connection to rubygems.org: success ✅

Hooray! This Ruby can connect to rubygems.org.
You are all set to use Bundler and RubyGems. 👌

PS C:\Greg\GitHub>
```