### PR TITLE
Add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+> [!WARNING]
+> This repo is deprecated because `bundle doctor --ssl` now provides information
+> to troubleshoot SSL issues. It will still be maintained until all supported
+> rubies ship with a version of Bundler providing `bundle doctor --ssl`, because
+> many times SSL issues prevent users from upgrading Bundler.
+
 # ruby-ssl-check
 
 This script tries to help you diagnose SSL problems, especially related to certificates or TLS version while connecting to https://rubygems.org.


### PR DESCRIPTION
We migrated this script to be part of `bundle doctor` at https://github.com/rubygems/rubygems/pull/8624, so we can deprecate this repo.